### PR TITLE
Adding python3 builds astropy stable

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -12,7 +12,7 @@
   # Continuum builds astropy for the latest numpy on py2 and py3. The
   # affiliated package template includes builds against older numpy
   # on python 2.7, so we'll build those.
-  python: '2.7*'  # if omitted, no restriction on python builds.
+  python: '2.7*|>=3.3'  # if omitted, no restriction on python builds.
 
   # Since we only need these for CI, only build on linux.
   excluded_platforms:


### PR DESCRIPTION
This should build the astropy stable release for older numpies and python3 versions to address and close #4.
