### PR TITLE
Pinning conda to 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
 
         # Define a numpy version that will be ignored anyway...
         - CONDA_NPY="1.11"
+        - CONDA_VERSION=4.2*
 
         # This controls how many older numpy versions are built.
         - MAX_NUMPY_MINOR_VERSIONS="5"
@@ -41,6 +42,9 @@ install:
     - bash miniconda.sh -b -p $CONDA_INSTALL_LOCN
     - export PATH=${CONDA_INSTALL_LOCN}/bin:$PATH
     - conda config --set always_yes true
+
+    - PIN_FILE_CONDA=${CONDA_INSTALL_LOCN}/conda-meta/pinned
+    - echo "conda ${CONDA_VERSION}" > $PIN_FILE_CONDA
 
     - conda update --quiet conda
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ environment:
 
   # This does not really matter but needs to be set...
   CONDA_NPY: "1.11"
+  CONDA_VERSION: "4.2.*"
 
   matrix:
     # Unfortunately, compiler/SDK configuration for 64 bit builds depends on
@@ -52,7 +53,7 @@ install:
     - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
 
     - cmd: conda config --set always_yes true
-    - cmd: conda update --quiet conda
+    - cmd: conda install --quiet conda=%CONDA_VERSION%
     - cmd: conda config --add channels astropy
     - cmd: conda config --add channels conda-forge
     - cmd: conda install --quiet astropy anaconda-client jinja2 cython


### PR DESCRIPTION
Basically the same was done in astropy/conda-channel-astropy, as ``conda-build`` is known to be incompatible with conda >=4.3