### PR TITLE
Building astropy stable with older numpies on windows, too

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,20 +56,17 @@ install:
     - cmd: conda install --quiet conda=%CONDA_VERSION%
     - cmd: conda config --add channels astropy
     - cmd: conda config --add channels conda-forge
+    - cmd: conda install conda-build=2.0.10
     - cmd: conda install --quiet astropy anaconda-client jinja2 cython
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil
     - cmd: conda install -c conda-forge conda-build-all
-    # - cmd: conda install --force conda-build=1.20.0
 
     # Finally, install extruder
     - cmd: conda install extruder
 
-    # Build the modified conda-build, if necessary...
-    - "%CMD_IN_ENV% conda build-all --inspect-channels=\"%DESTINATION_CONDA_CHANNEL%\" --upload-channels=\"%DESTINATION_CONDA_CHANNEL%\" --matrix-condition=\"python %PYTHON_BUILD_RESTRICTIONS%\" conda-build.recipe"
-    # Install custom version of conda-build for now (need to be able to pass
-    # options to setup.py)
-    - cmd: conda install -c astropy-ci-extras --override-channels --force conda-build
+    # To ease debugging, list installed packages
+    - cmd: conda info -a
 
 # Skip .NET project specific build phase.
 build: off
@@ -82,4 +79,4 @@ test_script:
     # Get ready to build.
     - "%CMD_IN_ENV% extrude_recipes requirements.yml"
     # Packages are uploaded as they are built.
-    - if exist recipes %CMD_IN_ENV% conda build-all --inspect-channels="%DESTINATION_CONDA_CHANNEL%" %UPLOAD% --matrix-condition="python %PYTHON_BUILD_RESTRICTIONS%" recipes
+    - if exist recipes %CMD_IN_ENV% conda build-all --inspect-channels="%DESTINATION_CONDA_CHANNEL%" %UPLOAD% --matrix-conditions "python %PYTHON_BUILD_RESTRICTIONS%" recipes

--- a/recipe_templates/astropy-stable/meta.yaml
+++ b/recipe_templates/astropy-stable/meta.yaml
@@ -7,11 +7,11 @@
 
 package:
   name: astropy
-  version: {{ version }}
+  version: "{{version}}"
 
 source:
-  fn: astropy-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/a/astropy/astropy-{{ version }}.tar.gz
+  fn: astropy-{{version}}.tar.gz
+  url: https://pypi.io/packages/source/a/astropy/astropy-{{version}}.tar.gz
 
 build:
   entry_points:

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,7 +16,6 @@
 
   # Since we only need these for CI, only build on linux.
   excluded_platforms:
-    - 'win-64'
     - 'osx-64'
 
 - name: astropy-lts


### PR DESCRIPTION
The windows builds were required by glue CI. This should close #10.