### PR TITLE
Adding pytest version 2.7.3, that was bundled into astropy LTS 1.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
         - DESTINATION_CONDA_CHANNEL="astropy-ci-extras"
         - TARGET_ARCH="x64"
         - CONDA_INSTALL_LOCN="${HOME}/miniconda"
+        - PACKAGES_TO_COPY="copy_me.yaml"
 
         # Defines BINSTAR_TOKEN for your binstar channel
         - secure: "WKr7RtLRuWln18nDNO7aWBJrcNUg8srYM3hotv7ozABZj2WSiHSG2G1v72MYnZX/6E3Hh1w7fN7IcB2u9XIEHXrJftjC0/xr4KCTrucOWwkRXRGV+CO9mkremI1QYuKhvAyRlSpmWZvp+AHDTcUmTR9oGP5ZEPY5zh63F+UTZqLuApmuBnlatYf07MmCn9/WC1wRGuL+da9JQjKoJSwgpSp9gmxjhiRQiY7X+/lPfTQXXAAMuhPIRLagEs64rutRqKkVOigwOjElpE+zBcPXS7ofs8lo4SIZq2j0FtEjVrCIxBwPTjxbuVDv4EK3/OHAxcrcXjwt1p4Qcx6wovUQ2C9W4avk4NTV0u05Yur3BzXOkRY4sv1loS7OHjbaZwOy6cb90v8ZIaPSFNoJ2oL2KmStdfb5VvdcY2KqdpUSLAB2SCSuOQhMDBOKmUoZBCFJIQ24ZUW7TtRnKBDxgr1+V6+z1CawUNia0juQDbJPhwFGFcQIEQ/d1AjWqHOBij1jfm7322CFJp5wWr0V2upM6HUI/sHIfmVBabK6eHhAztk4fCdlc/YmYYC39nCjhAeB8OrtA8jadmrNOd1uRalQd4qvC4HB0+VgjBm5DbQoKPRQUESEbDyxqqmVJcEBcDRPIlTdGjyUzivRThK+C1dZwlZwG7MF/DXz+nm1MH3xoEI="
@@ -56,7 +57,7 @@ install:
 
     # Bump defaults back up to the top priority
     - conda config --add channels defaults
-    - conda install conda-build=2.0.10
+    - conda install conda-build=2
     - conda install -c conda-forge conda-build-all
 
     # Finally, install extruder
@@ -73,6 +74,16 @@ script:
       fi
     # Get ready to build.
     - extrude_recipes requirements.yml
+    # If there are packages to copy, do that first, but only if UPLOAD is set,
+    # and only on Linux, since those travis machines are fastest. Copy only
+    # needs to happen once to copy all available builds.
+    - if [ -e $PACKAGES_TO_COPY ] && [ $TRAVIS_OS_NAME == "linux" ]; then
+        echo "Will potentially copy these packages when merged:";
+        cat $PACKAGES_TO_COPY;
+        if [ ! -z $UPLOAD ]; then
+          copy_packages $PACKAGES_TO_COPY $DESTINATION_CONDA_CHANNEL;
+        fi
+      fi
     # Packages are uploaded as they are built.
     # NOTE TO FUTURE: travis has a 4MB limit on log output. This can easily hit that
     # when building several versions, so direct output to a file, not stdout.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,9 @@ environment:
     - TARGET_ARCH: "x64"
       PYTHON_BUILD_RESTRICTIONS: "3.5*"
       CONDA_PY: "35"
-    # For 32 bit builds there are no compiler issues, let Obvious-CI
+    - TARGET_ARCH: "x64"
+      PYTHON_BUILD_RESTRICTIONS: "3.6*"
+      CONDA_PY: "36"    # For 32 bit builds there are no compiler issues, let Obvious-CI
     # handle the matrix.
     # - TARGET_ARCH: "x86"
     #   PYTHON_BUILD_RESTRICTIONS: "2.7*|>=3.4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ environment:
   # Anaconda.org channel to which packages should be uploaded.
   DESTINATION_CONDA_CHANNEL: "astropy-ci-extras"
 
+  # File with list of packages to potentially copy from conda-forge.
+  PACKAGES_TO_COPY: "copy_me.yaml"
+
   # Appveyor machines come with miniconda already installed.
   CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
 
@@ -65,12 +68,6 @@ install:
     # Finally, install extruder
     - cmd: conda install extruder
 
-    # Build the modified conda-build, if necessary...
-    - "%CMD_IN_ENV% conda build-all --inspect-channels=\"%DESTINATION_CONDA_CHANNEL%\" --upload-channels=\"%DESTINATION_CONDA_CHANNEL%\" --matrix-condition=\"python %PYTHON_BUILD_RESTRICTIONS%\" conda-build.recipe"
-    # Install custom version of conda-build for now (need to be able to pass
-    # options to setup.py)
-    - cmd: conda install -c astropy-ci-extras --override-channels --force conda-build
-
 # Skip .NET project specific build phase.
 build: off
 
@@ -81,5 +78,7 @@ test_script:
     - echo Upload is %UPLOAD%
     # Get ready to build.
     - "%CMD_IN_ENV% extrude_recipes requirements.yml"
+    # NOTE TO FUTURE: Do NOT bother to copy packages on the Windows side.
+    # Copying will copy for all platforms, no need to do it repetitively.
     # Packages are uploaded as they are built.
     - if exist recipes %CMD_IN_ENV% conda build-all --inspect-channels="%DESTINATION_CONDA_CHANNEL%" %UPLOAD% --matrix-condition="python %PYTHON_BUILD_RESTRICTIONS%" recipes

--- a/requirements.yml
+++ b/requirements.yml
@@ -33,3 +33,6 @@
   excluded_platforms:
     - 'win-64'
     - 'osx-64'
+
+- name: pytest
+  version: '2.7.3'


### PR DESCRIPTION
This version is not available on conda, and it's probably better to build a conda package than to terribly hack ci-helpers to pick up this version from pip for the LTS builds.