### PR TITLE
Adding pytest 3.1.4 

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -35,4 +35,4 @@
     - 'osx-64'
 
 - name: pytest
-  version: '2.7.3'
+  version: '3.1.3


### PR DESCRIPTION
we need that for the python3.4 builds to be able to pass the pytest 3.2 compatible parametrizations.